### PR TITLE
findPromotions: ignore users not in retrieved list

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,7 @@
 # `orglinter`
 
+- Fixed #16 - New users were causing an error in findPromotions
+
 ## 0.1.0
 
 - Initial MVP release

--- a/src/lib/checkers.js
+++ b/src/lib/checkers.js
@@ -22,7 +22,7 @@ function findDemotions(configured, retrieved) {
 
 function findPromotions(configured, retrieved) {
   const promotions = Object.keys(configured).filter(
-    (member) => configured[member] === 'ADMIN' && retrieved[member].role === 'MEMBER'
+    (member) => configured[member] === 'ADMIN' && retrieved[member] && retrieved[member].role === 'MEMBER'
   );
   console.log(`${promotions.length} promotions found: `, promotions);
   return promotions;

--- a/test/checkers.spec.js
+++ b/test/checkers.spec.js
@@ -51,6 +51,14 @@ describe('Checkers', function () {
       );
       assume(result).eqls(['zaphod']);
     });
+
+    it('ignores users not in retrieved list', function () {
+      const result = checkers.findPromotions(
+        { zaphod: 'ADMIN', trillian: 'ADMIN', marvin: 'MEMBER', ford: 'MEMBER' },
+        { zaphod: { role: 'MEMBER' }, marvin: { role: 'MEMBER' }, ford: { role: 'MEMBER' } }
+      );
+      assume(result).eqls(['zaphod']);
+    });
   });
 
   describe('validateTwoFactor', function () {


### PR DESCRIPTION
Fixes #16 

It looks like my suspicions in that bug report may have been correct. Before the fix, my test gave:

```
  1) Checkers
       findPromotions
         ignores users not in retrieved list:
     TypeError: Cannot read property 'role' of undefined
      at /Users/jwilhelm/Documents/workspace/godaddy/orglinter/src/lib/checkers.js:2:1624
      at Array.filter (<anonymous>)
      at Object.findPromotions (src/lib/checkers.js:2:1452)
      at Context.<anonymous> (test/checkers.spec.js:56:31)
      at processImmediate (node:internal/timers:463:21)
```

Should be all good now!