### PR TITLE
Set up JSDoc strings for the code

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -2,11 +2,14 @@
   "root": true,
   "extends": [
     "godaddy",
-    "plugin:mocha/recommended"
+    "plugin:jsdoc/recommended",
+    "plugin:mocha/recommended",
+    "plugin:node/recommended"
   ],
   "plugins": [
-    "eslint-plugin-mocha",
-    "eslint-plugin-node"
+    "jsdoc",
+    "mocha",
+    "node"
   ],
   "env": {
     "node": true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # `orglinter`
 
 - Fixed #16 - New users were causing an error in findPromotions
+- Fixed #20 - Added full JSDoc coverage across the code
 
 ## 0.1.0
 

--- a/bin/cli.js
+++ b/bin/cli.js
@@ -1,5 +1,6 @@
 #!/usr/bin/env node
 /* eslint-disable no-console, no-process-env, max-statements */
+'use strict';
 
 require('dotenv').config();
 const path = require('path');

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "assume": "^2.3.0",
         "eslint": "^7.15.0",
         "eslint-config-godaddy": "^4.0.1",
+        "eslint-plugin-jsdoc": "^31.6.1",
         "eslint-plugin-mocha": "^6.3.0",
         "eslint-plugin-node": "^11.1.0",
         "mocha": "^8.2.1",
@@ -885,6 +886,15 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "node_modules/comment-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+      "integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
+      "dev": true,
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    },
     "node_modules/commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -1138,6 +1148,27 @@
       },
       "peerDependencies": {
         "eslint": ">=4.19.1"
+      }
+    },
+    "node_modules/eslint-plugin-jsdoc": {
+      "version": "31.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.6.1.tgz",
+      "integrity": "sha512-5hCV3u+1VSEUMyfdTl+dpWsioD7tqQr2ILQw+KbXrF42AVxCLO8gnNLR6zDCDjqGGpt79V1sgY0RRchCWuCigg==",
+      "dev": true,
+      "dependencies": {
+        "comment-parser": "1.1.2",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.4",
+        "spdx-expression-parse": "^3.0.1"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "peerDependencies": {
+        "eslint": "^6.0.0 || ^7.0.0"
       }
     },
     "node_modules/eslint-plugin-json": {
@@ -2010,6 +2041,18 @@
         "js-yaml": "bin/js-yaml.js"
       }
     },
+    "node_modules/jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true,
+      "bin": {
+        "jsdoctypeparser": "bin/jsdoctypeparser"
+      },
+      "engines": {
+        "node": ">=10"
+      }
+    },
     "node_modules/jsesc": {
       "version": "2.5.2",
       "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-2.5.2.tgz",
@@ -2870,6 +2913,15 @@
         "node": ">=8"
       }
     },
+    "node_modules/regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+      "dev": true,
+      "engines": {
+        "node": ">=0.1.14"
+      }
+    },
     "node_modules/release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -3125,6 +3177,28 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "node_modules/spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "dependencies": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "node_modules/spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
     },
     "node_modules/sprintf-js": {
       "version": "1.0.3",
@@ -4480,6 +4554,12 @@
       "integrity": "sha1-p9BVi9icQveV3UIyj3QIMcpTvCU=",
       "dev": true
     },
+    "comment-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/comment-parser/-/comment-parser-1.1.2.tgz",
+      "integrity": "sha512-AOdq0i8ghZudnYv8RUnHrhTgafUGs61Rdz9jemU5x2lnZwAWyOq7vySo626K59e1fVKH1xSRorJwPVRLSWOoAQ==",
+      "dev": true
+    },
     "commondir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/commondir/-/commondir-1.0.1.tgz",
@@ -4686,6 +4766,21 @@
       "requires": {
         "eslint-utils": "^2.0.0",
         "regexpp": "^3.0.0"
+      }
+    },
+    "eslint-plugin-jsdoc": {
+      "version": "31.6.1",
+      "resolved": "https://registry.npmjs.org/eslint-plugin-jsdoc/-/eslint-plugin-jsdoc-31.6.1.tgz",
+      "integrity": "sha512-5hCV3u+1VSEUMyfdTl+dpWsioD7tqQr2ILQw+KbXrF42AVxCLO8gnNLR6zDCDjqGGpt79V1sgY0RRchCWuCigg==",
+      "dev": true,
+      "requires": {
+        "comment-parser": "1.1.2",
+        "debug": "^4.3.1",
+        "jsdoctypeparser": "^9.0.0",
+        "lodash": "^4.17.20",
+        "regextras": "^0.7.1",
+        "semver": "^7.3.4",
+        "spdx-expression-parse": "^3.0.1"
       }
     },
     "eslint-plugin-json": {
@@ -5329,6 +5424,12 @@
         "argparse": "^1.0.7",
         "esprima": "^4.0.0"
       }
+    },
+    "jsdoctypeparser": {
+      "version": "9.0.0",
+      "resolved": "https://registry.npmjs.org/jsdoctypeparser/-/jsdoctypeparser-9.0.0.tgz",
+      "integrity": "sha512-jrTA2jJIL6/DAEILBEh2/w9QxCuwmvNXIry39Ay/HVfhE3o2yVV0U44blYkqdHA/OKloJEqvJy0xU+GSdE2SIw==",
+      "dev": true
     },
     "jsesc": {
       "version": "2.5.2",
@@ -5985,6 +6086,12 @@
       "integrity": "sha512-ZOIzd8yVsQQA7j8GCSlPGXwg5PfmA1mrq0JP4nGhh54LaKN3xdai/vHUDu74pKwV8OxseMS65u2NImosQcSD0Q==",
       "dev": true
     },
+    "regextras": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/regextras/-/regextras-0.7.1.tgz",
+      "integrity": "sha512-9YXf6xtW+qzQ+hcMQXx95MOvfqXFgsKDZodX3qZB0x2n5Z94ioetIITsBtvJbiOyxa/6s9AtyweBLCdPmPko/w==",
+      "dev": true
+    },
     "release-zalgo": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/release-zalgo/-/release-zalgo-1.0.0.tgz",
@@ -6175,6 +6282,28 @@
         "signal-exit": "^3.0.2",
         "which": "^2.0.1"
       }
+    },
+    "spdx-exceptions": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/spdx-exceptions/-/spdx-exceptions-2.3.0.tgz",
+      "integrity": "sha512-/tTrYOC7PPI1nUAgx34hUpqXuyJG+DTHJTnIULG4rDygi4xu/tfgmq1e1cIRwRzwZgo4NLySi+ricLkZkw4i5A==",
+      "dev": true
+    },
+    "spdx-expression-parse": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/spdx-expression-parse/-/spdx-expression-parse-3.0.1.tgz",
+      "integrity": "sha512-cbqHunsQWnJNE6KhVSMsMeH5H/L9EpymbzqTQ3uLwNCLZ1Q481oWaofqH7nO6V07xlXwY6PhQdQ2IedWx/ZK4Q==",
+      "dev": true,
+      "requires": {
+        "spdx-exceptions": "^2.1.0",
+        "spdx-license-ids": "^3.0.0"
+      }
+    },
+    "spdx-license-ids": {
+      "version": "3.0.7",
+      "resolved": "https://registry.npmjs.org/spdx-license-ids/-/spdx-license-ids-3.0.7.tgz",
+      "integrity": "sha512-U+MTEOO0AiDzxwFvoa4JVnMV6mZlJKk2sBLt90s7G0Gd0Mlknc7kxEn3nuDPNZRta7O2uy8oLcZLVT+4sqNZHQ==",
+      "dev": true
     },
     "sprintf-js": {
       "version": "1.0.3",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "assume": "^2.3.0",
     "eslint": "^7.15.0",
     "eslint-config-godaddy": "^4.0.1",
+    "eslint-plugin-jsdoc": "^31.6.1",
     "eslint-plugin-mocha": "^6.3.0",
     "eslint-plugin-node": "^11.1.0",
     "mocha": "^8.2.1",

--- a/src/lib/checkers.js
+++ b/src/lib/checkers.js
@@ -2,6 +2,14 @@
 'use strict';
 
 /**
+ * A normalized member record retrieved from the GitHub GraphQL API
+ *
+ * @typedef {object} MemberRecord
+ * @property {string} role - The user's role in the org; "ADMIN" or "MEMBER"
+ * @property {boolean} hasTwoFactorEnabled - Whether the user has Two Factor Authentication enabled
+ */
+
+/**
  * Find users who currently belong to the organization, but not who are not
  * expected by config.
  *
@@ -34,7 +42,7 @@ function findNewMembers(configured, retrieved) {
  * to config.
  *
  * @param {object.<string, string>} configured - Configured usernames and their associated roles
- * @param {object.<string, object.<string, string>>} retrieved - User list retrieved from GitHub
+ * @param {object.<string, MemberRecord>} retrieved - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are admins, but should not be
  */
 function findDemotions(configured, retrieved) {
@@ -49,7 +57,7 @@ function findDemotions(configured, retrieved) {
  * Find users who are currently regular members of the org, but are configured as admins
  *
  * @param {object.<string, string>} configured - Configured usernames and their associated roles
- * @param {object.<string, object.<string, string>>} retrieved - User list retrieved from GitHub
+ * @param {object.<string, MemberRecord>} retrieved - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are not admins, but should be
  */
 function findPromotions(configured, retrieved) {
@@ -63,7 +71,7 @@ function findPromotions(configured, retrieved) {
 /**
  * Find org members who do not have two-factor authentication enabled
  *
- * @param {object.<string, object<string, boolean>>} members - User list retrieved from GitHub
+ * @param {object.<string, MemberRecord>} members - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are 2FA violators.
  */
 function validateTwoFactor(members) {

--- a/src/lib/checkers.js
+++ b/src/lib/checkers.js
@@ -1,18 +1,42 @@
 /* eslint-disable no-console */
 'use strict';
 
+/**
+ * Find users who currently belong to the organization, but not who are not
+ * expected by config.
+ *
+ * @param {string[]} configured - An array of usernames expected to exist in the org
+ * @param {string[]} retrieved - An array of usernames actually belong to the org currently
+ * @returns {string[]} An array of usernames which are not expected to belong to the org
+ */
 function findUndocumentedMembers(configured, retrieved) {
   const undocumented = retrieved.filter(member => !configured.includes(member));
   console.log(`${undocumented.length} undocumented memberships found: `, undocumented);
   return undocumented;
 }
 
+/**
+ * Find users who are expected by config, but who do not (yet) belong to the
+ * organization.
+ *
+ * @param {string[]} configured - An array of usernames expected to exist in the org
+ * @param {string[]} retrieved - An array of usernames actually belong to the org currently
+ * @returns {string[]} An array of usernames which are expected to belong to the org
+ */
 function findNewMembers(configured, retrieved) {
   const newMembers = configured.filter(member => !retrieved.includes(member));
   console.log(`${newMembers.length} new memberships requested: `, newMembers);
   return newMembers;
 }
 
+/**
+ * Find users who are currently admins of the org, but should not be, according
+ * to config.
+ *
+ * @param {object.<string, string>} configured - Configured usernames and their associated roles
+ * @param {object.<string, object.<string, string>>} retrieved - User list retrieved from GitHub
+ * @returns {string[]} An array of usernames who are admins, but should not be
+ */
 function findDemotions(configured, retrieved) {
   const demotions = Object.keys(retrieved).filter(
     (member) => retrieved[member].role === 'ADMIN' && configured[member] === 'MEMBER'
@@ -21,6 +45,13 @@ function findDemotions(configured, retrieved) {
   return demotions;
 }
 
+/**
+ * Find users who are currently regular members of the org, but are configured as admins
+ *
+ * @param {object.<string, string>} configured - Configured usernames and their associated roles
+ * @param {object.<string, object.<string, string>>} retrieved - User list retrieved from GitHub
+ * @returns {string[]} An array of usernames who are not admins, but should be
+ */
 function findPromotions(configured, retrieved) {
   const promotions = Object.keys(configured).filter(
     (member) => configured[member] === 'ADMIN' && retrieved[member] && retrieved[member].role === 'MEMBER'
@@ -29,12 +60,24 @@ function findPromotions(configured, retrieved) {
   return promotions;
 }
 
+/**
+ * Find org members who do not have two-factor authentication enabled
+ *
+ * @param {object.<string, object<string, boolean>>} members - User list retrieved from GitHub
+ * @returns {string[]} An array of usernames who are 2FA violators.
+ */
 function validateTwoFactor(members) {
   const violators = Object.keys(members).filter((member) => members[member].twoFactorAuth === false);
   console.log(`${violators.length} two factor auth violators found: `, violators);
   return violators;
 }
 
+/**
+ * Ensure that the org's current settings match those expected by the config
+ *
+ * @param {object.<string, *>} organization - The full collection of org settings collected from GitHub
+ * @param {object.<string, *>} config - The full collection of org settings expected by config
+ */
 function validateOrgSettings(organization, config) {
   let failed = false;
   for (const key of Object.keys(config)) {

--- a/src/lib/checkers.js
+++ b/src/lib/checkers.js
@@ -1,13 +1,7 @@
 /* eslint-disable no-console */
 'use strict';
 
-/**
- * A normalized member record retrieved from the GitHub GraphQL API
- *
- * @typedef {object} MemberRecord
- * @property {string} role - The user's role in the org; "ADMIN" or "MEMBER"
- * @property {boolean} hasTwoFactorEnabled - Whether the user has Two Factor Authentication enabled
- */
+const typedefs = require('./typedefs');
 
 /**
  * Find users who currently belong to the organization, but not who are not
@@ -42,7 +36,7 @@ function findNewMembers(configured, retrieved) {
  * to config.
  *
  * @param {object.<string, string>} configured - Configured usernames and their associated roles
- * @param {object.<string, MemberRecord>} retrieved - User list retrieved from GitHub
+ * @param {typedefs.MemberSet} retrieved - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are admins, but should not be
  */
 function findDemotions(configured, retrieved) {
@@ -57,7 +51,7 @@ function findDemotions(configured, retrieved) {
  * Find users who are currently regular members of the org, but are configured as admins
  *
  * @param {object.<string, string>} configured - Configured usernames and their associated roles
- * @param {object.<string, MemberRecord>} retrieved - User list retrieved from GitHub
+ * @param {typedefs.MemberSet} retrieved - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are not admins, but should be
  */
 function findPromotions(configured, retrieved) {
@@ -71,7 +65,7 @@ function findPromotions(configured, retrieved) {
 /**
  * Find org members who do not have two-factor authentication enabled
  *
- * @param {object.<string, MemberRecord>} members - User list retrieved from GitHub
+ * @param {typedefs.MemberSet} members - User list retrieved from GitHub
  * @returns {string[]} An array of usernames who are 2FA violators.
  */
 function validateTwoFactor(members) {

--- a/src/lib/checkers.js
+++ b/src/lib/checkers.js
@@ -1,4 +1,5 @@
 /* eslint-disable no-console */
+'use strict';
 
 function findUndocumentedMembers(configured, retrieved) {
   const undocumented = retrieved.filter(member => !configured.includes(member));

--- a/src/lib/fixers.js
+++ b/src/lib/fixers.js
@@ -3,6 +3,16 @@
 
 const { request } = require('@octokit/request');
 
+/**
+ * Invite a user to join an org
+ *
+ * @param {object} invitation - The details of the user invitation to be sent
+ * @param {string} invitation.username - The username to be invited
+ * @param {string} invitation.organization - The login name of the org where the user will be invited
+ * @param {string} invitation.token - A personal access token for interacting with the GitHub API
+ * @param {string} [invitation.role=member] - The role to invite the user as; "admin" or "member"
+ * @param {boolean} [invitation.dryRun=false] - If true, don't actually execute this operation
+ */
 async function inviteUser({ username, organization, token, role = 'member', dryRun = false }) {
   console.log(`Setting ${username} up as a(n) ${role} for ${organization}.`);
   if (dryRun) return;
@@ -22,6 +32,15 @@ async function inviteUser({ username, organization, token, role = 'member', dryR
   }
 }
 
+/**
+ * Remove a user from an org
+ *
+ * @param {object} removal - The details of the user removal to be initiated
+ * @param {string} removal.username - The username to be removed from the org
+ * @param {string} removal.organization - The login name of the org to remove the user from
+ * @param {string} removal.token - A personal access token for interacting with the GitHub API
+ * @param {boolean} removal.dryRun - If true, don't actally execute this operation
+ */
 async function removeMember({ username, organization, token, dryRun = false }) {
   console.log(`Removing ${username} from ${organization}.`);
   if (dryRun === true) return;
@@ -40,6 +59,15 @@ async function removeMember({ username, organization, token, dryRun = false }) {
   }
 }
 
+/**
+ * Promote a user from member to admin of an org
+ *
+ * @param {object} promotion - The details of the user promotion to be sent
+ * @param {string} promotion.username - The username to be promoted
+ * @param {string} promotion.organization - The login name of the org to promote the user in
+ * @param {string} promotion.token - A personal access token for interacting with the GitHub API
+ * @param {boolean} promotion.dryRun - If true, don't actally execute this operation
+ */
 async function promoteMember({ username, organization, token, dryRun = false }) {
   console.log(`Promoting ${username} to admin in ${organization}.`);
   if (dryRun) return;
@@ -47,6 +75,15 @@ async function promoteMember({ username, organization, token, dryRun = false }) 
   await inviteUser({ username, organization, token, role: 'admin' });
 }
 
+/**
+ * Demote a user from admin to member of an org
+ *
+ * @param {object} demotion - The details of the user demotion to be sent
+ * @param {string} demotion.username - The username to be demoted
+ * @param {string} demotion.organization - The login name of the org to demote the user in
+ * @param {string} demotion.token - A personal access token for interacting with the GitHub API
+ * @param {boolean} demotion.dryRun - If true, don't actally execute this operation
+ */
 async function demoteMember({ username, organization, token, dryRun = false }) {
   console.log(`Demoting ${username} to member in ${organization}.`);
   if (dryRun) return;

--- a/src/lib/fixers.js
+++ b/src/lib/fixers.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+'use strict';
+
 const { request } = require('@octokit/request');
 
 async function inviteUser({ username, organization, token, role = 'member', dryRun = false }) {

--- a/src/lib/loaders.js
+++ b/src/lib/loaders.js
@@ -4,7 +4,16 @@
 const fs = require('fs').promises;
 const { graphql } = require('@octokit/graphql');
 const TOML = require('@iarna/toml');
+const typedefs = require('./typedefs');
 
+
+/**
+ * Retrieve information from the GitHub GraphQL API about the requested org
+ *
+ * @param {string} orgName - The login name of the org to be retrieved
+ * @param {string} token - A personal access token for interacting with the API
+ * @returns {typedefs.OrgRecord} - The full details of the retrieved org
+ */
 async function retrieveOrgInfo(orgName, token) {
   let totalCount = 1, retrieved = 0, after = null, allMembers = [], pendingMembers, organization;
   const perPage = 100;

--- a/src/lib/loaders.js
+++ b/src/lib/loaders.js
@@ -100,6 +100,12 @@ async function retrieveOrgInfo(orgName, token) {
   return result;
 }
 
+/**
+ * Load an org's expected configuration from a TOML config file
+ *
+ * @param {string} fileName - The full path to the config file
+ * @returns {typedefs.ExpectedOrgConfig} - The full expected configuration of the org
+ */
 async function loadMembershipConfig(fileName) {
   const config = await TOML.parse.async(await fs.readFile(fileName));
   const allAdmins = new Set(

--- a/src/lib/loaders.js
+++ b/src/lib/loaders.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+'use strict';
+
 const fs = require('fs').promises;
 const { graphql } = require('@octokit/graphql');
 const TOML = require('@iarna/toml');

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -1,0 +1,32 @@
+'use strict';
+
+/**
+ * A normalized member record retrieved from the GitHub GraphQL API
+ *
+ * @typedef {object} MemberRecord
+ * @property {string} role - The user's role in the org; "ADMIN" or "MEMBER"
+ * @property {boolean} hasTwoFactorEnabled - Whether the user has Two Factor Authentication enabled
+ */
+
+/**
+ * A set of member records retrieved from the GitHub GraphQL API
+ *
+ * @typedef {object.<string, MemberRecord>} MemberSet
+ */
+
+/**
+ * A normalized org record retrieved from the GitHub GraphQL API
+ *
+ * @typedef {object} OrgRecord
+ * @global
+ * @property {string} email - The org's primary email address
+ * @property {boolean} isVerified - Whether the org has been verified by GitHub
+ * @property {string} login - The org's login name
+ * @property {MemberSet} members - The org's current membership
+ * @property {string} name - The org's display name
+ * @property {boolean} requiresTwoFactorAuthentication - Whether the org requires 2FA for membership
+ * @property {string} twitterUsername - The org's twitter username
+ * @property {string} websiteURL - The org's primary external website URL
+ */
+
+module.exports = {};

--- a/src/lib/typedefs.js
+++ b/src/lib/typedefs.js
@@ -18,7 +18,6 @@
  * A normalized org record retrieved from the GitHub GraphQL API
  *
  * @typedef {object} OrgRecord
- * @global
  * @property {string} email - The org's primary email address
  * @property {boolean} isVerified - Whether the org has been verified by GitHub
  * @property {string} login - The org's login name
@@ -27,6 +26,39 @@
  * @property {boolean} requiresTwoFactorAuthentication - Whether the org requires 2FA for membership
  * @property {string} twitterUsername - The org's twitter username
  * @property {string} websiteURL - The org's primary external website URL
+ */
+
+/**
+ * The expected configuration of a single GitHub team
+ *
+ * @typedef {object} ConfigTeam
+ * @property {string} name - The display name of the team
+ * @property {string} default_org_role - The org role assigned to members of this team; "ADMIN" or "MEMBER"
+ * @property {string} privacy - The public visibility of this team; "SECRET" or "VISIBLE"
+ * @property {Array.<string>} members - The users who are expected to be members of this team
+ */
+
+/**
+ * The expected configuration for the org entity itself
+ *
+ * @typedef {object} ConfigOrg
+ * @property {string} email - The org's expected email address
+ * @property {boolean} isVerified - Whether the org is expected to be verified by GitHub
+ * @property {string} login - The login name for the org; this is used for the API lookup
+ * @property {string} name - The org's expected display name
+ * @property {boolean} requiresTwoFactorAuthentication - Whether the org is expected to require 2FA for membership
+ * @property {string} twitterUsername - The org's expected twitter username
+ * @property {string} websiteUrl - The org's expected primary external website URL
+ */
+
+/**
+ * Structured data representing the expected configuration of a GitHub org
+ *
+ * @typedef {object} ExpectedOrgConfig
+ * @property {ConfigOrg} org - The expected configuration for the org entity itself
+ * @property {object.<string, string | Array.<string>>} members - A set of "internal" usernames paired up with GitHub usernames
+ * @property {object.<string, string>} github-members - GitHub usernames and their expected roles
+ * @property {Array.<ConfigTeam>} teams - The teams expected to exist in the org
  */
 
 module.exports = {};

--- a/test/checkers.spec.js
+++ b/test/checkers.spec.js
@@ -1,4 +1,6 @@
 /* eslint-disable no-console */
+'use strict';
+
 const assume = require('assume');
 const checkers = require('../src/lib/checkers');
 const sinon = require('sinon');


### PR DESCRIPTION
Fixes #20 

The goal of this PR is to fully document the code via JSDoc. In doing so, I ended up fixing up the linter config, because it seems like it may have just been failing silently previously. Or some of the rules just weren't triggering. One rule in particular reared its head: `strict`. Please somebody give me a sanity check on this to make sure I should be adding `'use strict';` in every source file! 😄 

@msluther Since you were specifically requesting this, do you want to turn your eye to these and make sure I'm getting them right?

Since the lack of JSDoc is only warnings and not tripping CI, I'll keep a running tally here:

* [x] Checkers documented
* [x] Fixers documented
* [x] Loaders documented
* [ ] CLI documented? Not sure this one makes sense.