### PR TITLE
Disable codecov

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,8 +30,6 @@ jobs:
         npm ci
         npm run build --if-present
         npm test
-    - name: Dump env
-      run: env
     # - name: Upload coverage to Codecov
     #   uses: codecov/codecov-action@v1
     #   with:

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -30,7 +30,9 @@ jobs:
         npm ci
         npm run build --if-present
         npm test
-    - name: Upload coverage to Codecov
-      uses: codecov/codecov-action@v1
-      with:
-        file: coverage/cobertura-coverage.xml
+    - name: Dump env
+      run: env
+    # - name: Upload coverage to Codecov
+    #   uses: codecov/codecov-action@v1
+    #   with:
+    #     file: coverage/cobertura-coverage.xml


### PR DESCRIPTION
Disabling codecov due to https://about.codecov.io/security-update/

First commit has an additional CI step of running `env` to show us a list of what may have been exposed. This step will be removed before merge.